### PR TITLE
chmod 0600 $swapname

### DIFF
--- a/btrfs-swapon
+++ b/btrfs-swapon
@@ -30,7 +30,7 @@ swapfile=$(losetup -f) #free loop device
 
 # set NOCOW
 touch $swapname
-chmod 0600 /swap
+chmod 0600 $swapname
 chattr +C $swapname
 head -c $swapsize /dev/zero >> $swapname
 


### PR DESCRIPTION
Putting a variable $swapname to command option (instead of hard link "/swap").