### PR TITLE
Just a little tuning service file

### DIFF
--- a/btrfs-swapon.service
+++ b/btrfs-swapon.service
@@ -2,6 +2,7 @@
 
 [Unit]
 Description=Turn on 4GiB swap on BTRFS
+After=syslog.target
 
 [Service]
 Type=oneshot
@@ -9,3 +10,6 @@ Environment="SWAPFILE=/4GiB.swap"
 RemainAfterExit=true
 ExecStart=/sbin/btrfs-swapon 4G ${SWAPFILE}
 ExecStop=/sbin/btrfs-swapoff ${SWAPFILE}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Just a little tuning to make ability to do "service enable " from default system's copy of the service file (/usr/lib/systemd/system/)
1

    cp btrfs-swapoff btrfs-swapon /sbin/
    cp btrfs-swapon.service /usr/lib/systemd/system/

2 and than - 

    systemctl enable btrfs-swapon.service

and check:

    systemctl is-enabled btrfs-swapon.service

SWAP will start after syslog - "After=syslog.target"